### PR TITLE
fix: add fallback for loading settings in ComfyUI Desktop

### DIFF
--- a/js/ta_aitools.js
+++ b/js/ta_aitools.js
@@ -201,8 +201,22 @@ async function onAiToolsIdChange(node, widget) {
         return;
     }
 
-    const baseUrl = taMenu.getBaseUrl();
-    const apiKey = taMenu.getApiKey();
+    let baseUrl = taMenu.getBaseUrl();
+    let apiKey = taMenu.getApiKey();
+
+    // Fallback: fetch from server settings if frontend settings are empty
+    if (!baseUrl || !apiKey) {
+        try {
+            const resp = await api.fetchApi('/api/settings', { cache: 'no-store' });
+            if (resp.status === 200) {
+                const settings = await resp.json();
+                baseUrl = baseUrl || settings['TensorArt.Settings.BaseUrl'] || '';
+                apiKey = apiKey || settings['TensorArt.Settings.ApiKey'] || '';
+            }
+        } catch (e) {
+            console.error("Failed to fetch settings from server:", e);
+        }
+    }
 
     if (!baseUrl || !apiKey) {
         console.error("Missing base url or api key");


### PR DESCRIPTION
## Summary
- In newer versions of ComfyUI Desktop, `app.extensionManager.setting.get()` may return empty values even when settings are properly configured via the API
- This causes the dynamic field widgets (including image upload buttons) to fail to load when entering an aiToolsId
- Added a fallback that fetches settings from the server API (`/api/settings`) when the frontend settings return empty

## Changes
- `js/ta_aitools.js`: When `taMenu.getBaseUrl()` or `taMenu.getApiKey()` returns empty, fetch from `/api/settings` as a fallback

## Test plan
- [ ] Configure BaseUrl and ApiKey via ComfyUI settings panel
- [ ] Create a TA AIToolsNode and enter an aiToolsId
- [ ] Verify dynamic fields (including image upload button) load correctly
- [ ] Verify the fix works on both standard ComfyUI and ComfyUI Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)